### PR TITLE
Update agnosticd ROSA config/playbooks

### DIFF
--- a/ansible/configs/rosa/README.adoc
+++ b/ansible/configs/rosa/README.adoc
@@ -16,13 +16,37 @@ The following config includes:
 
 == AWS Prereqs for ROSA
 
-Please see https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html for a list of pre-reqs for the target AWS account.
+- Please see https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html for a list of pre-reqs for the target AWS account.
+- An AWS EC2 key pair created via the EC2 Console or AWS CLI named `rosa_key` and of type RSA + PEM. This key is to access the EC2 bastion host where the ROSA deployment is initiated. After downloading it, run `chmod 400 rosa_key.pem` and store it in your `~/.ssh` folder.
+- On your deployment environment, you will need the following Ansible collections:
+
+```bash
+ansible-galaxy collection install community.crypto
+ansible-galaxy collection install ansible.posix
+ansible-galaxy collection install amazon.aws
+```
+
+== Configuration
+
+In a new file `custom_vars.yml` , configure the following parameters:
+
+- define a `cloud_provider: ec2`
+- define an email `email: <your-email>`. The email is required as metadata for the generated CloudFormation templates
+- update the default GUID `guid: ...`. It will be used as a suffix for all resources created including the ROSA cluster name. Length cannot exceed 10 characters.
 
 == Secrets
 
-You will need to define the `rosa_token` variable in order to deploy this config.  Add this variable to your secret file.
+In a new file `secrets.yml`, 
 
-This token can be created and downloaded from https://cloud.redhat.com/openshift/token/rosa
+- add a password for the following configuration `bastion_user_password`
+- add your ROSA token for the following configuration `rosa_token` (from <https://console.redhat.com/openshift/token/rosa>)
+- provide an AWS IAM access key ID and secret used for the ROSA cluster deployment: 
+
+```yaml
+aws_access_key_id: <my-aws_access_key_id>
+aws_secret_access_key: <my-aws_secret_access_key>
+```
+
 
 It should look like:
 
@@ -37,7 +61,9 @@ rosa_token: "eyJ<..REDACTED..>dz8"
 
 You can create yaml files of your desired configs and secrets and execute them:
 
-`ansible-playbook ansible/main.yaml -e @myenvironment-variables.yml  -e@my-secrets.yml`
+```
+ansible-playbook ansible/main.yml -e @ansible/configs/rosa/custom_vars.yml -e @ansible/configs/rosa/secrets.yml -vv -e ansible_python_interpreter=/usr/bin/python3 -i localhost, -c local
+```
 
 === To Delete an environment
 

--- a/ansible/configs/rosa/README.adoc
+++ b/ansible/configs/rosa/README.adoc
@@ -24,6 +24,7 @@ The following config includes:
 ansible-galaxy collection install community.crypto
 ansible-galaxy collection install ansible.posix
 ansible-galaxy collection install amazon.aws
+ansible-galaxy collection install community.aws
 ```
 
 == Configuration
@@ -33,6 +34,7 @@ In a new file `custom_vars.yml` , configure the following parameters:
 - define a `cloud_provider: ec2`
 - define an email `email: <your-email>`. The email is required as metadata for the generated CloudFormation templates
 - update the default GUID `guid: ...`. It will be used as a suffix for all resources created including the ROSA cluster name. Length cannot exceed 10 characters.
+- define AWS region `aws_region: <aws-regiond-id`
 
 == Secrets
 

--- a/ansible/configs/rosa/destroy_env.yml
+++ b/ansible/configs/rosa/destroy_env.yml
@@ -16,14 +16,13 @@
     - install_infra_ssh_key | default(false) | bool
 
   - name: Get fact for cloudformation stack
-    cloudformation_facts:
+    cloudformation_info:
       stack_name: "{{ project_tag }}"
     register: stack_facts
 
   - name: Grab and set stack creation time
-    when: project_tag in stack_facts.ansible_facts.cloudformation
     vars:
-      _stack_description: "{{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description }}"
+      _stack_description: "{{ stack_facts.cloudformation[project_tag].stack_description }}"
     set_fact:
       stack_creation_time: >-
         {{ _stack_description.creation_time | default(_stack_description.CreationTime) }}

--- a/ansible/configs/rosa/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/rosa/files/cloud_providers/ec2_cloud_template.j2
@@ -111,6 +111,7 @@ Resources:
 {% endfor %}
 {% endfor %}
 
+{% if skip_route53 is not defined or skip_route53 == false %}
   DnsZonePrivate:
     Type: "AWS::Route53::HostedZone"
     Properties:
@@ -152,8 +153,10 @@ Resources:
               - DnsZonePublic
               - NameServers
 {% endif %}
+{% endif %}
 
 {% for instance in instances %}
+{% if skip_route53 is not defined or skip_route53 == false %}
 {%   if instance['dns_loadbalancer'] | default(false) | bool
      and not instance['unique'] | default(false) | bool %}
   {{instance['name']}}DnsLoadBalancer:
@@ -186,6 +189,7 @@ Resources:
             - {{instance['name']}}{{c}}
             - PublicIp
 {%     endfor %}
+{%   endif %}
 {%   endif %}
 
 {%   for c in range(1,(instance['count'] |int)+1) %}
@@ -221,6 +225,7 @@ Resources:
       SubnetId:
         Ref: PublicSubnet
       Tags:
+{% if skip_route53 is not defined or skip_route53 == false %}
 {%     if instance['unique'] | d(false) | bool %}
         - Key: Name
           Value: {{instance['name']}}
@@ -232,6 +237,8 @@ Resources:
         - Key: internaldns
           Value: {{instance['name']}}{{loop.index}}.{{aws_dns_zone_private_chomped}}
 {%     endif %}
+{% endif %}
+
         - Key: "owner"
           Value: "{{ email | default('unknownuser') }}"
         - Key: "Project"
@@ -265,6 +272,7 @@ Resources:
             VolumeSize: "{{ vol.size }}"
 {%     endfor %}
 
+{% if skip_route53 is not defined or skip_route53 == false %}
   {{instance['name']}}{{loop.index}}InternalDns:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
@@ -320,9 +328,12 @@ Resources:
             - {{instance['name']}}{{loop.index}}
             - PublicIp
 {%     endif %}
+{% endif %}
+
 {%   endfor %}
 {% endfor %}
 
+{% if skip_route53 is not defined or skip_route53 == false %}
 {% if secondary_stack is not defined %}
   Route53User:
     Type: AWS::IAM::User
@@ -365,6 +376,7 @@ Resources:
         UserName:
           Ref: Route53User
 {% endif %}
+{% endif %}
 
   StudentUser:
     Type: AWS::IAM::User
@@ -398,6 +410,7 @@ Resources:
           Ref: StudentUser
 
 Outputs:
+{% if skip_route53 is not defined or skip_route53 == false %}
   Route53internalzoneOutput:
     Description: The ID of the internal route 53 zone
     Value:
@@ -418,6 +431,7 @@ Outputs:
         - SecretAccessKey
     Description: IAM User for Route53 (Let's Encrypt)
 {% endif %}
+{% endif %}
   StudentUser:
     Value:
       Ref: StudentUser
@@ -425,10 +439,10 @@ Outputs:
   StudentUserAccessKey:
     Value:
       Ref: StudentUserAccessKey
-    Description: IAM User for Route53 (Let's Encrypt)
+    Description: IAM User deploying ROSA
   StudentUserSecretAccessKey:
     Value:
       Fn::GetAtt:
         - StudentUserAccessKey
         - SecretAccessKey
-    Description: IAM User for Route53 (Let's Encrypt)
+    Description: IAM User deploying ROSA

--- a/ansible/configs/rosa/pre_infra_ec2.yml
+++ b/ansible/configs/rosa/pre_infra_ec2.yml
@@ -13,6 +13,6 @@
   aws_caller_info:
   register: _caller_info
 
-- name: Set  account ID
+- name: Set Route53 fact 
   set_fact:
-    sandbox_account_id: "{{ _caller_info.account }}"
+    skip_route53: "{{skip_route53}}"

--- a/ansible/configs/rosa/software.yml
+++ b/ansible/configs/rosa/software.yml
@@ -232,14 +232,6 @@
 
               *NOTE:* With great power comes great responsibility. We monitor usage.
 
-              *IMPORTANT:* Please be very careful to not expose AWS credentials in GIT repos or anywhere else that could be public!
-              If your credentials are compromised, your environment will be deleted without warning.
-
-              == Bastion SSH access:
-              * Password: {{ rosa_user_password }}
-              * Your AWS credentials are preconfigured in `~/.aws/credentials` on the bastion host.
-              * The ROSA CLI is preinstalled on the bastion host in `/usr/local/bin`. There is no need to use root.
-
               == OpenShift console access:
               * URL: {{ rosa_console_url.stdout }}
               * User: cluster-admin

--- a/ansible/configs/rosa/software.yml
+++ b/ansible/configs/rosa/software.yml
@@ -218,11 +218,9 @@
         - name: Save ansible vars to user_info data
           agnosticd_user_info:
             data:
-              rosa_sandbox_account_id: "{{ sandbox_account_id }}"
               rosa_console_user_name: "{{ hostvars.localhost.rosa_console_user_name }}"
               rosa_console_password: "{{ hostvars.localhost.rosa_console_password }}"
               rosa_bastion_user_name: "{{ bastion_user_name }}"
-              rosa_subdomain_base: "{{ subdomain_base }}"
               rosa_user_password: "{{ rosa_user_password }}"
               rosa_console_url: "{{ rosa_console_url.stdout }}"
               rosa_admin_password: "{{ rosa_admin_result.stdout }}"
@@ -234,16 +232,10 @@
 
               *NOTE:* With great power comes great responsibility. We monitor usage.
 
-              == AWS web console access:
-              * URL: https://{{ sandbox_account_id }}.signin.aws.amazon.com/console
-              * User: {{ hostvars.localhost.rosa_console_user_name }}
-              * Password: {{ hostvars.localhost.rosa_console_password }}
-
               *IMPORTANT:* Please be very careful to not expose AWS credentials in GIT repos or anywhere else that could be public!
               If your credentials are compromised, your environment will be deleted without warning.
 
               == Bastion SSH access:
-              * ssh {{ bastion_user_name }}@bastion.{{ subdomain_base }}
               * Password: {{ rosa_user_password }}
               * Your AWS credentials are preconfigured in `~/.aws/credentials` on the bastion host.
               * The ROSA CLI is preinstalled on the bastion host in `/usr/local/bin`. There is no need to use root.


### PR DESCRIPTION
- Add missing pre-requisites (Ansible collections)
- Provide option to not introduce domain name for VPC resources (bastion) since this is not required / used by ROSA as such
- Fix decommissioning playbook: Update cloudformation_facts module due to deprecation
- Documented mandatory parameters (`aws_region`, `cloud_provider`, `guid`, `email`, `output_dir`)

Other issue noted but not fixed (not blocking during a clean run): the deployment is not idempotent (CloudFormation failures related to the VPC Public subnet being recreated even if no code change was applied)